### PR TITLE
[iOS] Fix header search paths 

### DIFF
--- a/lib/ios/LottieReactNative.xcodeproj/project.pbxproj
+++ b/lib/ios/LottieReactNative.xcodeproj/project.pbxproj
@@ -269,6 +269,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/ReactCommon/**",
+					"$(SRCROOT)/../../../react-native/React/**",
+					"$(SRCROOT)/../../../react-native/ReactCommon/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -283,6 +285,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/ReactCommon/**",
+					"$(SRCROOT)/../../../react-native/React/**",
+					"$(SRCROOT)/../../../react-native/ReactCommon/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
`../../node_modules` is only work for example.

Also, I can't found `Lottie.framework` if I just use `react-native link` without CocoaPods, so it still not work, could we have a download link for that?