### PR TITLE
Fix build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ You can check out the example project with the following instructions
 
 1. Clone the repo: `git clone https://github.com/airbnb/lottie-react-native.git`
 2. Open: `cd lottie-react-native` and Install: `npm install`
+3. Run `npm start` to start the packager.
+4. In another CLI window, do the following:
 
 For Running iOS:
 
@@ -146,16 +148,30 @@ For Running Android:
 1. Run Example: `npm run run:android`
 
 
+## Troubleshooting
+
+If you are trying to run `pod install` and you get:
+
+```
+[!] Unable to find a specification for `lottie-ios`
+```
+
+Run `pod repo update` and retry.
+
 
 ## Alternatives
+
 1. Build animations by hand. Building animations by hand is a huge time commitment for design and engineering across Android and iOS. It's often hard or even impossible to justify spending so much time to get an animation right.
 2. [Facebook Keyframes](https://github.com/facebookincubator/Keyframes). Keyframes is a wonderful new library from Facebook that they built for reactions. However, Keyframes doesn't support some of Lottie's features such as masks, mattes, trim paths, dash patterns, and more.
 2. Gifs. Gifs are more than double the size of a bodymovin JSON and are rendered at a fixed size that can't be scaled up to match large and high density screens.
 3. Png sequences. Png sequences are even worse than gifs in that their file sizes are often 30-50x the size of the bodymovin json and also can't be scaled up.
 
+
 ## Why is it called Lottie?
+
 Lottie is named after a German film director and the foremost pioneer of silhouette animation. Her best known films are The Adventures of Prince Achmed (1926) – the oldest surviving feature-length animated film, preceding Walt Disney's feature-length Snow White and the Seven Dwarfs (1937) by over ten years
 [The art of Lotte Reineger](https://www.youtube.com/watch?v=LvU55CUw5Ck&feature=youtu.be)
+
 
 ## Contributing
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,4 +1,3 @@
-use_frameworks!
 
 target 'example' do
   pod 'React', :path => '../../node_modules/react-native', :subspecs => [

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,22 +1,28 @@
 PODS:
   - lottie-ios (1.0.0)
-  - lottie-react-native (0.1.0):
+  - lottie-react-native (1.0.0):
     - lottie-ios
     - React
-  - React (0.38.1):
-    - React/Core (= 0.38.1)
-  - React/Core (0.38.1)
-  - React/RCTAnimation (0.38.1):
+  - React (0.41.0):
+    - React/Core (= 0.41.0)
+  - React/Core (0.41.0):
+    - React/cxxreact
+    - React/yoga
+  - React/cxxreact (0.41.0):
+    - React/jschelpers
+  - React/jschelpers (0.41.0)
+  - React/RCTAnimation (0.41.0):
     - React/Core
-  - React/RCTImage (0.38.1):
+  - React/RCTImage (0.41.0):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.38.1):
+  - React/RCTNetwork (0.41.0):
     - React/Core
-  - React/RCTText (0.38.1):
+  - React/RCTText (0.41.0):
     - React/Core
-  - React/RCTWebSocket (0.38.1):
+  - React/RCTWebSocket (0.41.0):
     - React/Core
+  - React/yoga (0.41.0)
 
 DEPENDENCIES:
   - lottie-react-native (from `../../`)
@@ -35,9 +41,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   lottie-ios: c40d67c1481d6fb9fa24fe46731ac823f5f6675b
-  lottie-react-native: 4a05f65415072faa22edeb1c1112063b69b8431d
-  React: 2c6b27dcaea89b3d3398df8b598330fd18abbe46
+  lottie-react-native: 921a5f992f705e7aa2ef1fadf7812fa5ad05e333
+  React: f290d57d4e567e69ef5a231ff461dbf9dac8da46
 
-PODFILE CHECKSUM: 85d709a79f1639fb2278dee5bd3fc72dcab22bac
+PODFILE CHECKSUM: f599da013d7c1939292ba2072269e5bcb78acf43
 
 COCOAPODS: 1.2.0

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		DFDF16F73573AE2D8EB8E0EC /* Pods_example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66D5CAB7C80C8DD566604F93 /* Pods_example.framework */; };
+		7D5584585D4C63E75BDC4A89 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 30E13AEAFADC888C8529C0F3 /* libPods-example.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,7 +26,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = example/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = example/main.m; sourceTree = "<group>"; };
 		28437A2E6F046829179DC2CD /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Pods/Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
-		66D5CAB7C80C8DD566604F93 /* Pods_example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		30E13AEAFADC888C8529C0F3 /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7809FEEC607AFE668DA36D62 /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -35,7 +35,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DFDF16F73573AE2D8EB8E0EC /* Pods_example.framework in Frameworks */,
+				7D5584585D4C63E75BDC4A89 /* libPods-example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,7 +106,7 @@
 		84CD571D1DFFE83100ECC964 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				66D5CAB7C80C8DD566604F93 /* Pods_example.framework */,
+				30E13AEAFADC888C8529C0F3 /* libPods-example.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/lib/ios/LottieReactNative/LottieAnimationViewManager.h
+++ b/lib/ios/LottieReactNative/LottieAnimationViewManager.h
@@ -6,7 +6,14 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
+// import RCTViewManager.h
+#if __has_include("RCTViewManager.h")
 #import "RCTViewManager.h"
+#elif __has_include(<React/RCTViewManager.h>)
+#import <React/RCTViewManager.h>
+#else
+#import "React/RCTViewManager.h"
+#endif
 
 @interface LottieAnimationViewManager : RCTViewManager
 

--- a/lib/ios/LottieReactNative/LottieAnimationViewManager.m
+++ b/lib/ios/LottieReactNative/LottieAnimationViewManager.m
@@ -9,9 +9,24 @@
 #import "LottieAnimationViewManager.h"
 
 #import "LottieContainerView.h"
+
+// import RCTBridge.h
+#if __has_include("RCTBridge.h")
 #import "RCTBridge.h"
+#elif __has_include(<React/RCTBridge.h>)
+#import <React/RCTBridge.h>
+#else
+#import "React/RCTBridge.h"
+#endif
+
+// import RCTUIManager.h
+#if __has_include("RCTUIManager.h")
 #import "RCTUIManager.h"
-#import <Lottie/Lottie.h>
+#elif __has_include(<React/RCTUIManager.h>)
+#import <React/RCTUIManager.h>
+#else
+#import "React/RCTUIManager.h"
+#endif
 
 @implementation LottieAnimationViewManager
 

--- a/lib/ios/LottieReactNative/LottieAnimationViewManager.m
+++ b/lib/ios/LottieReactNative/LottieAnimationViewManager.m
@@ -28,6 +28,8 @@
 #import "React/RCTUIManager.h"
 #endif
 
+#import <Lottie/Lottie.h>
+
 @implementation LottieAnimationViewManager
 
 RCT_EXPORT_MODULE(LottieAnimationView)

--- a/lib/ios/LottieReactNative/LottieContainerView.h
+++ b/lib/ios/LottieReactNative/LottieContainerView.h
@@ -7,7 +7,15 @@
 //
 
 
+// import RCTView.h
+#if __has_include("RCTView.h")
 #import "RCTView.h"
+#elif __has_include(<React/RCTView.h>)
+#import <React/RCTView.h>
+#else
+#import "React/RCTView.h"
+#endif
+
 #import <Lottie/Lottie.h>
 
 @interface LottieContainerView : RCTView

--- a/lib/ios/LottieReactNative/LottieContainerView.m
+++ b/lib/ios/LottieReactNative/LottieContainerView.m
@@ -8,7 +8,14 @@
 
 #import "LottieContainerView.h"
 
+// import UIView+React.h
+#if __has_include("UIView+React.h")
 #import "UIView+React.h"
+#elif __has_include(<React/UIView+React.h>)
+#import <React/UIView+React.h>
+#else
+#import "React/UIView+React.h"
+#endif
 
 @implementation LottieContainerView {
   LAAnimationView *_animationView;

--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -6,10 +6,8 @@ import {
   View,
   Platform,
   StyleSheet,
-  NativeModules,
 } from 'react-native';
 import SafeModule from 'react-native-safe-module';
-import deline from 'deline';
 
 const NativeLottieView = SafeModule.component({
   viewName: 'LottieAnimationView',
@@ -28,11 +26,11 @@ const ViewStyleExceptBorderPropType = (props, propName, componentName, ...rest) 
   const flattened = StyleSheet.flatten(props[propName]);
   const usesBorder = Object.keys(flattened).some(key => key.startsWith('border'));
   if (usesBorder) {
-    return Error(deline`
-      ${componentName} does not allow any border related style properties to be specified. Border 
-      styles for this component will behave differently across platforms. If you'd like to render a 
-      border around this component, wrap it with a View.
-    `);
+    return Error(
+      `${componentName} does not allow any border related style properties to be specified. ` +
+      'Border styles for this component will behave differently across platforms. If you\'d like ' +
+      'to render a border around this component, wrap it with a View.'
+    );
   }
   return View.propTypes.style(props, propName, componentName, ...rest);
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "^6.1.2",
     "gitbook-cli": "^1.0.1",
     "react": "^15.4.1",
-    "react-native": "^0.38.1"
+    "react-native": "^0.41.0"
   },
   "rnpm": {
     "android": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react-native": ">=0.35"
   },
   "dependencies": {
-    "deline": "^1.0.2",
     "invariant": "^2.2.2",
     "react-native-safe-module": "^1.1.0"
   },


### PR DESCRIPTION
Fixes #25 
Fixes #20 
Closes #18 
Closes #23 

I've tested these changes with RN 0.41 as well as RN 0.38 and I believe it's backwards compatible.
The only limitation is that with RN >= 0.40, this will not work with CocoaPods + `use_frameworks!`, which as far as I can tell is a community-wide issue with RN 0.40+ right now, and probably won't be fixed until RN 0.42.