### PR TITLE
Adds framework search paths for Lottie.framework installed with carthage

### DIFF
--- a/lib/ios/LottieReactNative.xcodeproj/project.pbxproj
+++ b/lib/ios/LottieReactNative.xcodeproj/project.pbxproj
@@ -226,11 +226,17 @@
 		11FA5C5B1C4A1296003AC2EE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/**",
+					"$(SRCROOT)/../../../../ios/Carthage/Build/iOS",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/ReactCommon/**",
 					"$(SRCROOT)/../../../react-native/React/**",
 					"$(SRCROOT)/../../../react-native/ReactCommon/**",
+					"$(SRCROOT)/../../../../ios/Carthage/Build/iOS/**",
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -242,11 +248,17 @@
 		11FA5C5C1C4A1296003AC2EE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/**",
+					"$(SRCROOT)/../../../../ios/Carthage/Build/iOS",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/ReactCommon/**",
 					"$(SRCROOT)/../../../react-native/React/**",
 					"$(SRCROOT)/../../../react-native/ReactCommon/**",
+					"$(SRCROOT)/../../../../ios/Carthage/Build/iOS/**",
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Hey there, 

This PR is somewhat dirty in that I did not think about process / style etc. However it solves the following problem : 

- Install lottie-ios with Carthage
  - Make the framework available within the project witht he usual carthage manipulations
- install lottie-react-native with npm
  - link etc

Problem : the files within the lottie-react-native subproject cannot access the contents of Lottie.framework because it does not know where to find them

Solution : add this somewhat standard path to the Framework Search Path of the lottie-react-native subproject so that it can access and use them.

I feel like there are more fit solutions to this problem that could be expressed by actual xcode / ios experts, which I'm not. This did solve the issue though.

If you feel like this should be a thing but the PR is dirty, please advice, I will absolutely clean up :)

P.S. This is the only acceptable approach for me because my build is handled by a CI server that reinstalls every npm dependency for each build.