### PR TITLE
[Android] Add imageAssetsFolder prop

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,11 @@ type AnimationProps = {
   // http://facebook.github.io/react-native/releases/0.39/docs/view.html#style
   // CAVEAT: border styling is not supported.
   style?: ViewStyle,
+
+  // [Android] Relative folder inside of assets containing image files to be animated.
+  // Make sure that the images that bodymovin export are in that folder with their names unchanged (should be img_#). 
+  // Refer to https://github.com/airbnb/lottie-android#image-support for more details.
+  imageAssetsFolder: string,
 };
 
 ```

--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -102,4 +102,9 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   public void setLoop(LottieAnimationView view, boolean loop) {
     view.loop(loop);
   }
+
+  @ReactProp(name = "imageAssetsFolder")
+  public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
+    view.setImageAssetsFolder(imageAssetsFolder);
+  }
 }


### PR DESCRIPTION
This PR adds support for imageAssetsFolder prop - see [airbnb/lottie-android#image-support](https://github.com/airbnb/lottie-android#image-support).

**Example**
```
<Animation
  style={{
    width: 200,
    height: 200,
  }}
  source={require('./data.json')}
  progress={this.state.progress}
  imageAssetsFolder={'lottie/images'}
/>
```
<img width="238" alt="capture d ecran 2017-03-30 a 00 46 45" src="https://cloud.githubusercontent.com/assets/5569608/24479992/66cfe6ee-14e2-11e7-8ff7-5eff85095829.png">

**Tasks**
- [x] Add imageAssetsFolder prop
- [x] Update docs