### PR TITLE
Reading all numbers as double from ReadableMap and ReadableArray

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/JSONReadableArray.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/JSONReadableArray.java
@@ -148,11 +148,7 @@ class JSONReadableArray extends JSONArray {
         case Boolean:
           return getBoolean(index);
         case Number:
-          try {
-            return getInt(index);
-          } catch (Exception e) {
             return getDouble(index);
-          }
         case String:
           return getString(index);
         case Null:

--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/JSONReadableMap.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/JSONReadableMap.java
@@ -128,11 +128,7 @@ class JSONReadableMap extends JSONObject {
       case Boolean:
         return map.getBoolean(name);
       case Number:
-        try {
-          return map.getInt(name);
-        } catch (Exception e) {
           return map.getDouble(name);
-        }
       case String:
         return map.getString(name);
       case Null:


### PR DESCRIPTION
One of our AfterEffect json file was not working properly in lottie-react-native. But was working fine in lottie-react-native. Verified it by placing json in to official examples. 

After spending some time in code, figured out the problem. The problem is `JSONReadableMap.java` and `JSONReadableArray.java` files are converting `Number` type to `Integer` by default and reading as `Double` on exception. This seems to be causing some issues and stripping off decimal values.

```java
  @Override
  public Object opt(String name) {
    switch (map.getType(name)) {
    ...
      case Number:
        try {
          return map.getInt(name);
        } catch (Exception e) {
          return map.getDouble(name);
        }
    ...
    }
  }
```

Got animation working fine by changing the default type to double. 

```java
  @Override
  public Object opt(String name) {
    switch (map.getType(name)) {
    ...
      case Number:
          return map.getDouble(name);
    ...
    }
  }
```


