### PR TITLE
Upgrade to ViewPropTypes instead of View.PropTypes

### DIFF
--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -6,6 +6,7 @@ import {
   View,
   Platform,
   StyleSheet,
+  ViewPropTypes,
 } from 'react-native';
 import SafeModule from 'react-native-safe-module';
 
@@ -32,7 +33,7 @@ const ViewStyleExceptBorderPropType = (props, propName, componentName, ...rest) 
       'to render a border around this component, wrap it with a View.'
     );
   }
-  return View.propTypes.style(props, propName, componentName, ...rest);
+  return ViewPropTypes.style(props, propName, componentName, ...rest);
 };
 
 const NotAllowedPropType = (props, propName, componentName) => {
@@ -44,7 +45,7 @@ const NotAllowedPropType = (props, propName, componentName) => {
 };
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   style: ViewStyleExceptBorderPropType,
   children: NotAllowedPropType,
   progress: PropTypes.number,


### PR DESCRIPTION
Using `View.propTypes` is outdated since rn@0.44.