### PR TITLE
Publish configuration options

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -4,6 +4,7 @@ apply from: 'gradle-maven-push.gradle'
 android {
   compileSdkVersion 25
   buildToolsVersion "25.0.2"
+  publishNonDefault true
 
   defaultConfig {
     minSdkVersion 16


### PR DESCRIPTION
Some build tasks need to be able to specify configuration in lottie eg:

    compile project(path: ':lottie', configuration: 'release')

To do this, we need to publish these configuration options to the parent projects.