### PR TITLE
Use prop-types package (PropTypes in React package is deprecated)

### DIFF
--- a/example/ExamplePicker.js
+++ b/example/ExamplePicker.js
@@ -1,9 +1,10 @@
 /* eslint-disable global-require */
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   Picker,
   Platform,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   example: PropTypes.any,

--- a/example/PlayerControls.js
+++ b/example/PlayerControls.js
@@ -1,5 +1,5 @@
 /* eslint-disable global-require */
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   View,
   Text,
@@ -7,6 +7,7 @@ import {
   Switch,
   Button,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   progress: PropTypes.any, // animated

--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   findNodeHandle,
   UIManager,
@@ -9,6 +9,7 @@ import {
   ViewPropTypes,
 } from 'react-native';
 import SafeModule from 'react-native-safe-module';
+import PropTypes from 'prop-types';
 
 const NativeLottieView = SafeModule.component({
   viewName: 'LottieAnimationView',

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   },
   "dependencies": {
     "invariant": "^2.2.2",
-    "react-native-safe-module": "^1.1.0",
-    "lottie-ios": "^1.5.2"
+    "lottie-ios": "^1.5.2",
+    "prop-types": "^15.5.10",
+    "react-native-safe-module": "^1.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Because `PropTypes` is not available anymore in newer React packages, we need to use the standalone `prop-types` package to keep using PropTypes functionality.

See https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes