### PR TITLE
Feature/support react 0.47

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/LottiePackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/LottiePackage.java
@@ -15,10 +15,6 @@ public class LottiePackage implements ReactPackage {
     return Collections.emptyList();
   }
 
-  @Override public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
   @SuppressWarnings("rawtypes") @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.<ViewManager>singletonList(new LottieAnimationViewManager());

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/airbnb/lottie-react-native#readme",
   "peerDependencies": {
     "react": ">=15.3.1",
-    "react-native": "*"
+    "react-native": ">0.47.0"
   },
   "dependencies": {
     "invariant": "^2.2.2",
@@ -60,7 +60,7 @@
     "eslint-plugin-react": "^6.1.2",
     "gitbook-cli": "^1.0.1",
     "react": "^15.4.1",
-    "react-native": "^0.41.1"
+    "react-native": "^0.47.0"
   },
   "rnpm": {
     "android": {


### PR DESCRIPTION
As of `react-native` relase v0.47.0 `createJSModules` method is no
longer available.

Reference: https://github.com/facebook/react-native/releases/tag/v0.47.0