### PR TITLE
Use linear easing in examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ export default class BasicExample extends React.Component {
     Animated.timing(this.state.progress, {
       toValue: 1,
       duration: 5000,
-      easing: Easing.linear
+      easing: Easing.linear,
     }).start();
   }
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Lottie's animation progress can be controlled with an `Animated` value:
 
 ```jsx
 import React from 'react';
-import { Animated } from 'react-native';
+import { Animated, Easing } from 'react-native';
 import Animation from 'lottie-react-native';
 
 export default class BasicExample extends React.Component {
@@ -107,6 +107,7 @@ export default class BasicExample extends React.Component {
     Animated.timing(this.state.progress, {
       toValue: 1,
       duration: 5000,
+      easing: Easing.linear
     }).start();
   }
 

--- a/example/LottieAnimatedExample.js
+++ b/example/LottieAnimatedExample.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   View,
   Animated,
+  Easing,
   StyleSheet,
 } from 'react-native';
 import Animation from 'lottie-react-native';
@@ -55,6 +56,7 @@ export default class LottieAnimatedExample extends React.Component {
       Animated.timing(this.state.progress, {
         toValue: 1,
         duration: this.state.config.duration,
+        easing: Easing.linear,
       }).start(({ finished }) => {
         if (finished) this.forceUpdate();
       });
@@ -69,6 +71,7 @@ export default class LottieAnimatedExample extends React.Component {
       Animated.timing(this.state.progress, {
         toValue: 0,
         duration: this.state.config.duration,
+        easing: Easing.linear,
       }).start(({ finished }) => {
         if (finished) this.forceUpdate();
       });


### PR DESCRIPTION
By default, `Animated.timing` uses the `Easing.inOut(Easing.ease)` easing function. This means that animations do not play quite as expected. I think that the majority use case will be for linear easing and should be documented: those unfamiliar with the `Animated` API may not be aware of the default behaviour.