### PR TITLE
Expose a new prop to enable merge paths on android

### DIFF
--- a/example/LottieAnimatedExample.js
+++ b/example/LottieAnimatedExample.js
@@ -104,6 +104,7 @@ export default class LottieAnimatedExample extends React.Component {
             }}
             source={EXAMPLES[this.state.example].getJson()}
             progress={this.state.progress}
+            enableMergePaths={true}
           />
         </View>
       </View>

--- a/example/LottieAnimatedExample.js
+++ b/example/LottieAnimatedExample.js
@@ -104,7 +104,7 @@ export default class LottieAnimatedExample extends React.Component {
             }}
             source={EXAMPLES[this.state.example].getJson()}
             progress={this.state.progress}
-            enableMergePaths={true}
+            enableMergePaths
           />
         </View>
       </View>

--- a/example/LottieAnimatedExample.js
+++ b/example/LottieAnimatedExample.js
@@ -104,7 +104,7 @@ export default class LottieAnimatedExample extends React.Component {
             }}
             source={EXAMPLES[this.state.example].getJson()}
             progress={this.state.progress}
-            enableMergePaths
+            enableMergePathsAndroidForKitKatAndAbove
           />
         </View>
       </View>

--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -109,4 +109,9 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     view.setImageAssetsFolder(imageAssetsFolder);
   }
+
+  @ReactProp(name = "enableMergePaths")
+  public void setEnableMergePaths(LottieAnimationView view, boolean enableMergePaths) {
+    view.enableMergePathsForKitKatAndAbove(enableMergePaths);
+  }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -110,7 +110,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     view.setImageAssetsFolder(imageAssetsFolder);
   }
 
-  @ReactProp(name = "enableMergePaths")
+  @ReactProp(name = "enableMergePathsAndroidForKitKatAndAbove")
   public void setEnableMergePaths(LottieAnimationView view, boolean enableMergePaths) {
     view.enableMergePathsForKitKatAndAbove(enableMergePaths);
   }

--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -63,7 +63,7 @@ const defaultProps = {
   progress: 0,
   speed: 1,
   loop: false,
-  enableMergePaths: false
+  enableMergePaths: false,
 };
 
 const viewConfig = {

--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -52,6 +52,7 @@ const propTypes = {
   progress: PropTypes.number,
   speed: PropTypes.number,
   loop: PropTypes.bool,
+  enableMergePaths: PropTypes.bool,
   source: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
@@ -62,6 +63,7 @@ const defaultProps = {
   progress: 0,
   speed: 1,
   loop: false,
+  enableMergePaths: false
 };
 
 const viewConfig = {

--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -52,7 +52,7 @@ const propTypes = {
   progress: PropTypes.number,
   speed: PropTypes.number,
   loop: PropTypes.bool,
-  enableMergePaths: PropTypes.bool,
+  enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
@@ -63,7 +63,7 @@ const defaultProps = {
   progress: 0,
   speed: 1,
   loop: false,
-  enableMergePaths: false,
+  enableMergePathsAndroidForKitKatAndAbove: false,
 };
 
 const viewConfig = {


### PR DESCRIPTION
This should fix https://github.com/airbnb/lottie-react-native/issues/185.

I don't have the warning saying `Animation contains merge paths but they are disabled.` but sadly I tried with an animation with merge paths that is working on iOS and it only rendered a blank space on android.