### PR TITLE
Prevent crash when underlying native view is destroyed

### DIFF
--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -134,11 +134,15 @@ LottieAnimation.defaultProps = defaultProps;
 const Animation = Animated.createAnimatedComponent(LottieAnimation);
 
 Animation.prototype.play = function play() {
-  return this.getNode().play();
+  if (this.getNode()) {
+    return this.getNode().play();
+  }
 };
 
 Animation.prototype.reset = function pause() {
-  return this.getNode().reset();
+  if (this.getNode()) {
+    return this.getNode().reset();
+  }
 };
 
 module.exports = Animation;

--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -136,12 +136,16 @@ const Animation = Animated.createAnimatedComponent(LottieAnimation);
 Animation.prototype.play = function play() {
   if (this.getNode()) {
     return this.getNode().play();
+  } else {
+    console.warn('Trying to animate a view on an unmounted component');
   }
 };
 
 Animation.prototype.reset = function pause() {
   if (this.getNode()) {
     return this.getNode().reset();
+  } else {
+    console.warn('Trying to animate a view on an unmounted component');
   }
 };
 


### PR DESCRIPTION
Hi !

We are using a lot of Lottie animation in our apps and sometimes we are experiencing a crash because the reference doesn't exist anymore (ie when the user switch screen to fast). 
We added a check on the reference every time we call a method on the Animated component but sometime that's not enough and we got a crash here https://github.com/airbnb/lottie-react-native/blob/master/lib/js/Animation.js#L137 ( `null is not an object (evaluating 'this.getNode().play')`).

Maybe this could be checked in the Animated component like I'm suggesting in this PR.