### PR TITLE
Added the functionality of setting the Speed of the Animation for Android

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
 |---|---|---|
 |**`source`**| **Mandatory** - The source of animation. Can be referenced as a local asset by a string, or remotely with an object with a `uri` property, or it can be an actual JS object of an animation, obtained (for example) with something like `require('../path/to/animation.json')` |*None*|
 |**`progress`**| A number between 0 and 1, or an `Animated` number between 0 and 1. This number represents the normalized progress of the animation. If you update this prop, the animation will correspondingly update to the frame at that progress value. This prop is not required if you are using the imperative API. |`0`|
-|**`speed`**| The speed the animation will progress. This only affects the imperative API. |`1`|
+|**`speed`**| The speed the animation will progress. This only affects the imperative API. Sending a negative value will reverse the animation |`1`|
 |**`loop`**|A boolean flag indicating whether or not the animation should loop. |`false`|
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|

--- a/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -97,7 +97,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
 
   @ReactProp(name = "speed")
   public void setSpeed(LottieAnimationView view, double speed) {
-    // TODO?
+    view.setSpeed((float)speed);
   }
 
   @ReactProp(name = "loop")


### PR DESCRIPTION
## What's there in this PR?
* Completed the missing `setSpeed` functionality in the ReactNative Android library.
* Added documentation around the usage of `setSpeed` according to the native implementation of `LottieAnimationView`