### PR TITLE
[fix] eliminate warning on older RN version

### DIFF
--- a/lib/js/Animation.js
+++ b/lib/js/Animation.js
@@ -34,7 +34,7 @@ const ViewStyleExceptBorderPropType = (props, propName, componentName, ...rest) 
       'to render a border around this component, wrap it with a View.'
     );
   }
-  return ViewPropTypes.style(props, propName, componentName, ...rest);
+  return (ViewPropTypes || View.propTypes).style(props, propName, componentName, ...rest);
 };
 
 const NotAllowedPropType = (props, propName, componentName) => {


### PR DESCRIPTION
In my case, I use react native 0.40.0, it shows "Warning: Failed prop type: Cannot read property 'style' of undefined".