### PR TITLE
move eslint packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,8 @@
     "react-native": ">=0.46"
   },
   "dependencies": {
-    "eslint-config-prettier": "^2.8.0",
-    "eslint-plugin-prettier": "^2.3.1",
     "invariant": "^2.2.2",
     "lottie-ios": "^2.1.5",
-    "prettier": "^1.8.2",
-    "prettier-eslint": "^8.2.2",
     "prop-types": "^15.5.10",
     "react-native-safe-module": "^1.1.0"
   },
@@ -64,7 +60,11 @@
     "eslint-plugin-react": "^6.1.2",
     "gitbook-cli": "^1.0.1",
     "react": "16.0.0",
-    "react-native": "0.50.3"
+    "react-native": "0.50.3",
+    "eslint-config-prettier": "^2.8.0",
+    "eslint-plugin-prettier": "^2.3.1",
+    "prettier": "^1.8.2",
+    "prettier-eslint": "^8.2.2"
   },
   "rnpm": {
     "android": {


### PR DESCRIPTION
currently those dependencies are being installed in our work modules and create conflicts with eslint versions.