### PR TITLE
Expose Android's hardwareAcceleration as prop

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -123,11 +123,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     view.loop(loop);
   }
 
-  @ReactProp(name = "hardwareAcceleration")
+  @ReactProp(name = "hardwareAccelerationAndroid")
   public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
     view.useHardwareAcceleration(use);
   }
- 
+
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     view.setImageAssetsFolder(imageAssetsFolder);

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -123,6 +123,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     view.loop(loop);
   }
 
+  @ReactProp(name = "hardwareAcceleration")
+  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
+    view.useHardwareAcceleration(use);
+  }
+ 
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     view.setImageAssetsFolder(imageAssetsFolder);

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -1,16 +1,15 @@
+import React from 'react';
 import {
+  findNodeHandle,
+  UIManager,
   Animated,
+  View,
   Platform,
   StyleSheet,
-  UIManager,
-  View,
   ViewPropTypes,
-  findNodeHandle,
 } from 'react-native';
-
-import PropTypes from 'prop-types';
-import React from 'react';
 import SafeModule from 'react-native-safe-module';
+import PropTypes from 'prop-types';
 
 const NativeLottieView = SafeModule.component({
   viewName: 'LottieAnimationView',

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -64,7 +64,7 @@ const defaultProps = {
   loop: true,
   enableMergePathsAndroidForKitKatAndAbove: false,
   resizeMode: 'contain',
-  style: StyleSheet.absoluteFill
+  style: StyleSheet.absoluteFill,
 };
 
 const viewConfig = {

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -55,7 +55,7 @@ const propTypes = {
   loop: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  hardwareAcceleration: PropTypes.bool
+  hardwareAcceleration: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -1,15 +1,16 @@
-import React from 'react';
 import {
-  findNodeHandle,
-  UIManager,
   Animated,
-  View,
   Platform,
   StyleSheet,
+  UIManager,
+  View,
   ViewPropTypes,
+  findNodeHandle,
 } from 'react-native';
-import SafeModule from 'react-native-safe-module';
+
 import PropTypes from 'prop-types';
+import React from 'react';
+import SafeModule from 'react-native-safe-module';
 
 const NativeLottieView = SafeModule.component({
   viewName: 'LottieAnimationView',
@@ -55,7 +56,7 @@ const propTypes = {
   loop: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  hardwareAcceleration: PropTypes.bool,
+  hardwareAccelerationAndroid: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -55,6 +55,7 @@ const propTypes = {
   loop: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+  hardwareAcceleration: PropTypes.bool
 };
 
 const defaultProps = {
@@ -63,7 +64,7 @@ const defaultProps = {
   loop: true,
   enableMergePathsAndroidForKitKatAndAbove: false,
   resizeMode: 'contain',
-  style: StyleSheet.absoluteFill,
+  style: StyleSheet.absoluteFill
 };
 
 const viewConfig = {

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -69,7 +69,7 @@ export interface AnimationProps extends ViewProperties {
    * and height, e.g. you are not scaling the animation.
    * @platform android
    */
-  hardwareAcceleration?: boolean;
+  hardwareAccelerationAndroid?: boolean;
 }
 
 export default class Animation extends React.Component<AnimationProps, {}> {


### PR DESCRIPTION
Per https://github.com/airbnb/lottie-android/issues/151, hardware acceleration for large animations is often helpful, provided the animation has not been scaled beyond its original dimensions.