### PR TITLE
Add features from easy-lottie-react-native

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@
 |**`progress`**| A number between 0 and 1, or an `Animated` number between 0 and 1. This number represents the normalized progress of the animation. If you update this prop, the animation will correspondingly update to the frame at that progress value. This prop is not required if you are using the imperative API. |`0`|
 |**`speed`**| The speed the animation will progress. This only affects the imperative API. Sending a negative value will reverse the animation |`1`|
 |**`loop`**|A boolean flag indicating whether or not the animation should loop. |`false`|
+|**`autoSize`**|A boolean flag indicating whether or not the animation should size itself automatically according to the width in the animation's JSON. This only works when `source` is an actual JS object of an animation.  |`false`|
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@
 |**`progress`**| A number between 0 and 1, or an `Animated` number between 0 and 1. This number represents the normalized progress of the animation. If you update this prop, the animation will correspondingly update to the frame at that progress value. This prop is not required if you are using the imperative API. |`0`|
 |**`speed`**| The speed the animation will progress. This only affects the imperative API. Sending a negative value will reverse the animation |`1`|
 |**`loop`**|A boolean flag indicating whether or not the animation should loop. |`false`|
+|**`autoPlay`**|A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.  |`false`|
 |**`autoSize`**|A boolean flag indicating whether or not the animation should size itself automatically according to the width in the animation's JSON. This only works when `source` is an actual JS object of an animation.  |`false`|
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@
 |**`source`**| **Mandatory** - The source of animation. Can be referenced as a local asset by a string, or remotely with an object with a `uri` property, or it can be an actual JS object of an animation, obtained (for example) with something like `require('../path/to/animation.json')` |*None*|
 |**`progress`**| A number between 0 and 1, or an `Animated` number between 0 and 1. This number represents the normalized progress of the animation. If you update this prop, the animation will correspondingly update to the frame at that progress value. This prop is not required if you are using the imperative API. |`0`|
 |**`speed`**| The speed the animation will progress. This only affects the imperative API. Sending a negative value will reverse the animation |`1`|
-|**`loop`**|A boolean flag indicating whether or not the animation should loop. |`false`|
+|**`loop`**|A boolean flag indicating whether or not the animation should loop. |`true`|
 |**`autoPlay`**|A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.  |`false`|
 |**`autoSize`**|A boolean flag indicating whether or not the animation should size itself automatically according to the width in the animation's JSON. This only works when `source` is an actual JS object of an animation.  |`false`|
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -61,17 +61,29 @@ export default class LottieAnimatedExample extends React.Component {
 
   onPlayPress() {
     if (this.state.imperative) {
-      this.anim.play();
+      if (!this.state.isPlaying) {
+        this.anim.play();
+      } else {
+        this.anim.reset();
+      }
     } else {
-      this.state.progress.setValue(0.5);
-      Animated.timing(this.state.progress, {
-        toValue: 1,
-        duration: this.state.duration,
-        easing: Easing.linear,
-      }).start(({ finished }) => {
-        if (finished) this.forceUpdate();
-      });
+      this.state.progress.setValue(0);
+
+      if (!this.state.isPlaying) {
+        Animated.timing(this.state.progress, {
+          toValue: 1,
+          duration: this.state.duration,
+          easing: Easing.linear,
+        }).start(({ finished }) => {
+          if (finished) {
+            this.setState({ isPlaying: false });
+            this.forceUpdate();
+          }
+        });
+      }
     }
+
+    this.setState({ isPlaying: !this.state.isPlaying });
   }
 
   onInversePress() {

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -48,7 +48,6 @@ export default class LottieAnimatedExample extends React.Component {
       loop: true,
     };
     this.onValueChange = this.onValueChange.bind(this);
-    this.onPlayPress = this.onPlayPress.bind(this);
     this.onInversePress = this.onInversePress.bind(this);
     this.setAnim = this.setAnim.bind(this);
   }
@@ -57,7 +56,7 @@ export default class LottieAnimatedExample extends React.Component {
     this.state.progress.setValue(value);
   }
 
-  onPlayPress(shouldPlay = !this.state.isPlaying) {
+  manageAnimation = shouldPlay => {
     if (!this.state.progress) {
       if (shouldPlay) {
         this.anim.play();
@@ -81,12 +80,13 @@ export default class LottieAnimatedExample extends React.Component {
     }
 
     this.setState({ isPlaying: shouldPlay });
-  }
+  };
 
-  stopAnimation = () => this.onPlayPress(false);
+  onPlayPress = () => this.manageAnimation(!this.state.isPlaying);
+  stopAnimation = () => this.manageAnimation(false);
 
   onInversePress() {
-    this.setState(state => ({ ...state, isInverse: !state.isInverse }));
+    this.setState(state => ({ isInverse: !state.isInverse }));
   }
 
   setAnim(anim) {
@@ -119,7 +119,10 @@ export default class LottieAnimatedExample extends React.Component {
         <View style={{ paddingBottom: 20, paddingHorizontal: 10 }}>
           <View style={styles.controlsRow}>
             <TouchableOpacity
-              onPress={() => this.setState(state => ({ ...state, loop: !state.loop }))}
+              onPress={() => {
+                this.stopAnimation();
+                this.setState(state => ({ loop: !state.loop }));
+              }}
               disabled={!!progress}
             >
               <Image

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -43,7 +43,7 @@ export default class LottieAnimatedExample extends React.Component {
     this.state = {
       example: Object.keys(EXAMPLES)[0],
       duration: 3000,
-      isPlaying: false,
+      isPlaying: true,
       isInverse: false,
       loop: true,
     };
@@ -106,6 +106,7 @@ export default class LottieAnimatedExample extends React.Component {
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <LottieView
             ref={this.setAnim}
+            autoPlay
             style={[
               selectedExample.width && { width: selectedExample.width },
               isInverse && styles.lottieViewInvse,

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -101,7 +101,10 @@ export default class LottieAnimatedExample extends React.Component {
         <ExamplePicker
           example={example}
           examples={EXAMPLES}
-          onChange={e => this.setState({ example: e })}
+          onChange={e => {
+            this.stopAnimation();
+            this.setState({ example: e });
+          }}
         />
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <LottieView

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -75,7 +75,6 @@ export default class LottieAnimatedExample extends React.Component {
         }).start(({ finished }) => {
           if (finished) {
             this.setState({ isPlaying: false });
-            this.forceUpdate();
           }
         });
       }

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -19,9 +19,10 @@ const pauseIcon = require('./images/pause.png');
 const loopIcon = require('./images/loop.png');
 const inverseIcon = require('./images/inverse.png');
 
-const makeExample = (name, getJson) => ({ name, getJson });
+const makeExample = (name, getJson, width) => ({ name, getJson, width });
 const EXAMPLES = [
   makeExample('Hamburger Arrow', () => require('./animations/HamburgerArrow.json')),
+  makeExample('Hamburger Arrow (200 px)', () => require('./animations/HamburgerArrow.json'), 200),
   makeExample('Line Animation', () => require('./animations/LineAnimation.json')),
   makeExample('Lottie Logo 1', () => require('./animations/LottieLogo1.json')),
   makeExample('Lottie Logo 2', () => require('./animations/LottieLogo2.json')),
@@ -83,19 +84,22 @@ export default class LottieAnimatedExample extends React.Component {
 
   render() {
     const { duration, imperative, isPlaying, isInverse, progress, loop, example } = this.state;
-
+    const selectedExample = EXAMPLES[example];
     return (
-      <View style={StyleSheet.absoluteFill}>
+      <View style={{ flex: 1 }}>
         <ExamplePicker
-          example={this.state.example}
+          example={example}
           examples={EXAMPLES}
           onChange={e => this.setState({ example: e })}
         />
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <LottieView
             ref={this.setAnim}
-            style={[StyleSheet.absoluteFill, isInverse && styles.lottieViewInvse]}
-            source={EXAMPLES[example].getJson()}
+            style={[
+              selectedExample.width && { width: selectedExample.width },
+              isInverse && styles.lottieViewInvse,
+            ]}
+            source={selectedExample.getJson()}
             progress={this.state.progress}
             loop={loop}
             enableMergePathsAndroidForKitKatAndAbove

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -51,7 +51,7 @@ const propTypes = {
   style: ViewStyleExceptBorderPropType,
   children: NotAllowedPropType,
   resizeMode: PropTypes.oneOf(['cover', 'contain', 'center']),
-  progress: PropTypes.number,
+  progress: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   speed: PropTypes.number,
   loop: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -54,6 +54,7 @@ const propTypes = {
   progress: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   speed: PropTypes.number,
   loop: PropTypes.bool,
+  autoSize: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   hardwareAccelerationAndroid: PropTypes.bool,
@@ -63,6 +64,7 @@ const defaultProps = {
   progress: 0,
   speed: 1,
   loop: true,
+  autoSize: false,
   enableMergePathsAndroidForKitKatAndAbove: false,
   resizeMode: 'contain',
 };
@@ -122,7 +124,7 @@ class LottieView extends React.Component {
   }
 
   render() {
-    const { style, source, ...rest } = this.props;
+    const { style, source, autoSize, ...rest } = this.props;
 
     const sourceName = typeof source === 'string' ? source : undefined;
     const sourceJson = typeof source === 'string' ? undefined : JSON.stringify(source);
@@ -130,10 +132,10 @@ class LottieView extends React.Component {
     const aspectRatioStyle = sourceJson ? { aspectRatio: source.w / source.h } : undefined;
 
     const styleObject = StyleSheet.flatten(style);
-    const sizeStyle =
-      !styleObject || (styleObject.width === undefined && styleObject.height === undefined)
-        ? StyleSheet.absoluteFill
-        : undefined;
+    let sizeStyle;
+    if (!styleObject || (styleObject.width === undefined && styleObject.height === undefined)) {
+      sizeStyle = autoSize && sourceJson ? { width: source.w } : StyleSheet.absoluteFill;
+    }
 
     return (
       <View style={[aspectRatioStyle, sizeStyle, style]}>

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -54,6 +54,7 @@ const propTypes = {
   progress: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   speed: PropTypes.number,
   loop: PropTypes.bool,
+  autoPlay: PropTypes.bool,
   autoSize: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
@@ -64,6 +65,7 @@ const defaultProps = {
   progress: 0,
   speed: 1,
   loop: true,
+  autoPlay: false,
   autoSize: false,
   enableMergePathsAndroidForKitKatAndAbove: false,
   resizeMode: 'contain',
@@ -121,6 +123,9 @@ class LottieView extends React.Component {
 
   refRoot(root) {
     this.root = root;
+    if (this.props.autoPlay) {
+      this.play();
+    }
   }
 
   render() {


### PR DESCRIPTION
Hello,

Here is some features from https://github.com/bamlab/easy-lottie-react-native/issues/1, there's everything except:
- automatic duration according to the animation's JSON data (I might do another PR). With the `autoPlay` prop that I added here, it becomes a bit useless (with the imperative API, the correct duration is taken into account)
- the fix for Android animation's JSON data bug, I couldn't reproduce it here, lottie-android must have fixed it already ! 👌

The PR became a bit big along the way, let me know if you want that I break it down :)

- adds automatic aspectRatio according to the animation's JSON data (won't work when the source is a native asset)
- adds `autoSize` prop that will size the prop according to the animation's JSON data (won't work when the source is a native asset), defaults to false for the moment, but this might be great for newcomers that it becomes true per default in a newer release
- adds `autoPlay` prop that will play the animation when the animation is loaded
- fixes some propTypes
- [demo] fixes the pause button. There's still a bug left because the imperative API doesn't have a completion event yet. I plan on doing another PR ;)
- [demo] fixes behaviour when interacting with the UI (essentially stop the animation so that's more clear to the user)
- a bit of code cleaning
