### PR TITLE
Support Carthage projects

### DIFF
--- a/src/ios/LottieReactNative.xcodeproj/project.pbxproj
+++ b/src/ios/LottieReactNative.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		11FA5C5B1C4A1296003AC2EE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../../ios/Carthage/Build/iOS";
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/ReactCommon/**",
@@ -242,6 +243,7 @@
 		11FA5C5C1C4A1296003AC2EE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../../ios/Carthage/Build/iOS";
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/ReactCommon/**",


### PR DESCRIPTION
This pull request adds support for iOS projects that use [Carthage](https://github.com/Carthage/Carthage) for iOS dependencies instead of Cocoapods.
Carthage is used a lot in the iOS community and it would be great to add support for it.

How to test?
1. [Add Lottie to your Cartfile ](http://airbnb.io/lottie/ios.html#installing-lottie)
2. Run `carthage update`
3. Link react native `react-native link lottie-react-native`