### PR TITLE
Update @lottiefiles/dotlottie-react dependencies to support react 19 (required for RN 0.78 + Expo SDK 53)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "react-native-windows": ">=0.63.x"
   },
   "peerDependenciesMeta": {
-    "@lottiefiles/-react": {
+    "@lottiefiles/dotlottie-react": {
       "optional": true
     },
     "react-native-windows": {


### PR DESCRIPTION
@emilioicai @TheRogue76  Hello, please merge this. It is required to use the latest React native version, otherwise there will be dependencies conflicts.
