### PR TITLE
make lottiefiles/dotlottie-react dependency version to *

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "lint-fix:swift": "swiftlint --fix ios"
   },
   "peerDependencies": {
-    "@lottiefiles/dotlottie-react": "^0.6.5",
+    "@lottiefiles/dotlottie-react": "*",
     "react": "*",
     "react-native": ">=0.46",
     "react-native-windows": ">=0.63.x"
@@ -55,7 +55,7 @@
     }
   },
   "devDependencies": {
-    "@lottiefiles/dotlottie-react": "^0.6.5",
+    "@lottiefiles/dotlottie-react": "*",
     "@react-native-community/eslint-config": "^3.1.0",
     "@release-it/conventional-changelog": "^5.1.1",
     "@types/react": "^18.2.12",


### PR DESCRIPTION
I've already created PR #1342, but I think this is probably a much cleaner solution as it makes compatibility much easier!