### PR TITLE
fix: RN [0.82] import for `TextAttributeProps.UNSET`

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -20,7 +20,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.views.text.ReactFontManager
-import com.facebook.react.views.text.TextAttributeProps.UNSET
+import com.facebook.react.common.ReactConstants.UNSET
 import com.facebook.react.util.RNLog
 import java.lang.ref.WeakReference
 import java.util.regex.Pattern


### PR DESCRIPTION
Lottie won't compile with 0.82, that's due to us converting `TextAttributeProps` to Kotlin. 

So the import should either be converted to `import ... TextAttributeProps.Companion.UNSET`

or better to `ReactConstants.UNSET`