### PR TITLE
fix: improve animation loading by clearing previous view

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -168,6 +168,9 @@ class ContainerView: RCTView {
             return
         }
 
+        // Immediately clear the previous animation view so the region is blank while loading
+        removeCurrentAnimationView()
+
         _ = LottieAnimationView(
             dotLottieUrl: url,
             configuration: lottieConfiguration,
@@ -195,6 +198,9 @@ class ContainerView: RCTView {
         }
 
         guard let url = url else { return }
+
+        // Immediately clear the previous animation view so the region is blank while loading
+        removeCurrentAnimationView()
 
         self.fetchRemoteAnimation(from: url)
     }
@@ -276,8 +282,20 @@ class ContainerView: RCTView {
     }
 
     // MARK: Private
+    private func removeCurrentAnimationView() {
+        if let current = animationView {
+            // Remove from view hierarchy
+            current.removeFromSuperview()
+            // Clear layer contents to prevent any rendering artifacts
+            current.layer.contents = nil
+            // Clear the reference
+            animationView = nil
+        }
+    }
+
     func replaceAnimationView(next: LottieAnimationView) {
-        super.removeReactSubview(animationView)
+        // Ensure any existing view is properly detached from UIKit hierarchy
+        removeCurrentAnimationView()
 
         animationView = next
 


### PR DESCRIPTION
Added a method to immediately clear the current animation view before loading a new animation, preventing rendering artifacts during the transition. This change enhances the user experience by ensuring a blank region while the new animation is being fetched.



Issue this PR Resolve : https://github.com/lottie-react-native/lottie-react-native/issues/1380#issuecomment-3527763687
Repro to reproduce this issue : https://github.com/aman003malhotra/lottie-ios-issue