### PR TITLE
fix: add number type to source prop

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,7 @@ export interface LottieViewProps {
    * animation, obtained (for example) with something like
    * `require('../path/to/animation.json')`
    */
-  source: string | AnimationObject | { uri: string };
+  source: string | AnimationObject | { uri: string } | number;
 
   /**
    * A number between 0 and 1, or an `Animated` number between 0 and 1. This number


### PR DESCRIPTION
Fixes #1403

### Bug

The source prop's TypeScript type was missing number from its union type, even though the JSDoc comment explicitly mentions using `require('../path/to/animation.json')` — which returns a number in React Native.

This caused a TypeScript error when passing a require()'d asset:

```
// TS error: Type 'number' is not assignable to type 'string | AnimationObject | { uri: string }'
  <LottieView source={require('./animation.json')} />
```

This error also occurs when using the import syntax, e.g.

```
import MyLottieAnimation from '@assets/MyLottieAnimation.lottie'

<LottieView source={MyLottieAnimation} />
```

### Fix

Added number to the source prop union type in packages/core/src/types.ts:

`source: string | AnimationObject | { uri: string } | number;`