### PR TITLE
fix: CAlayer ambiguous expression on macOS

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -287,7 +287,7 @@ class ContainerView: RCTView {
             // Remove from view hierarchy
             current.removeFromSuperview()
             // Clear layer contents to prevent any rendering artifacts
-            current.layer.contents = nil
+            current.layer?.contents = nil
             // Clear the reference
             animationView = nil
         }

--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -286,8 +286,12 @@ class ContainerView: RCTView {
         if let current = animationView {
             // Remove from view hierarchy
             current.removeFromSuperview()
-            // Clear layer contents to prevent any rendering artifacts
-            current.layer?.contents = nil
+            // Clear layer contents to prevent any rendering artifacts 
+            #if !os(macOS) 
+                current.layer.contents = nil
+            #else
+                current.layer?.contents = nil
+            #endif
             // Clear the reference
             animationView = nil
         }


### PR DESCRIPTION
Building lottie-react-native version 7.3.6 on macOS results in the following error:
```
node_modules/lottie-react-native/ios/LottieReactNative/ContainerView.swift:290:36: type of expression is ambiguous without a type annotation

            current.layer.contents = nil
            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```

This happens because CALayer is optional on AppKit, this PR fixes it by adding a simple `?`
