### PR TITLE
docs: fix stale org clone URL and package name references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ After forking to your own github org, do the following steps to get started:
 
 ```bash
 # clone your fork to your local machine
-git clone https://github.com/airbnb/lottie-react-native.git
+git clone https://github.com/lottie-react-native/lottie-react-native.git
 
 # step into local repo
 cd lottie-react-native

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ module.exports = {
 
 ## API
 
-You can find the full list of props and methods available in our [API document](https://github.com/airbnb/lottie-react-native/blob/master/docs/api.md). These are the most common ones:
+You can find the full list of props and methods available in our [API document](https://github.com/lottie-react-native/lottie-react-native/blob/master/docs/api.md). These are the most common ones:
 
 | Prop               | Description                                                                                                                                                                                                                                                                     | Default                                                                                                                         |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -278,7 +278,7 @@ You can find the full list of props and methods available in our [API document](
 | **`autoPlay`**     | A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.                                                                                                                                           | `false`                                                                                                                         |
 | **`colorFilters`** | An array of objects denoting layers by KeyPath and a new color filter value (as hex string).                                                                                                                                                                                    | `[]`                                                                                                                            |
 
-[More...](https://github.com/airbnb/lottie-react-native/blob/master/docs/api.md)
+[More...](https://github.com/lottie-react-native/lottie-react-native/blob/master/docs/api.md)
 
 ## Troubleshooting
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ When creating animations using AfterEffects and bodymovin, the exported json may
   ...
 ```
 
-To make `react-native-lottie` use those assets properly, it is necessary to go for the native route: so remember that you need to **fully** rebuild your application if you modify the images / add new ones.
+To make `lottie-react-native` use those assets properly, it is necessary to go for the native route: so remember that you need to **fully** rebuild your application if you modify the images / add new ones.
 
 ### Android
 


### PR DESCRIPTION
A few docs still point at the old `airbnb/lottie-react-native` location and one uses the wrong package name. This updates them.

- CONTRIBUTING.md: the `git clone` command used `https://github.com/airbnb/lottie-react-native.git`, which now 301-redirects to this org. Updated it to `https://github.com/lottie-react-native/lottie-react-native.git`.
- README.md: the two "API document" links (the API section and the "More..." link) also still used `airbnb/lottie-react-native`. Pointed them at `lottie-react-native/lottie-react-native`.
- docs/api.md: the asset-handling note referred to the package as `react-native-lottie`. The actual package name is `lottie-react-native` (see `packages/core/package.json`), so I corrected it. `react-native-lottie` is a separate, unrelated npm package.

Left the `airbnb/lottie-ios`, `airbnb/lottie-android`, `airbnb/lottie`, and `airbnb.io/lottie` links untouched since those still resolve and are the correct upstreams.

Docs only, no code changes.