### PR TITLE
feat: expose Android opacity layer option

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
@@ -307,6 +307,14 @@ internal object LottieAnimationViewManagerImpl {
     }
 
     @JvmStatic
+    fun setApplyOpacityToLayers(
+        applyOpacityToLayers: Boolean,
+        viewManager: LottieAnimationViewPropertyManager
+    ) {
+        viewManager.applyOpacityToLayers = applyOpacityToLayers
+    }
+
+    @JvmStatic
     fun setEnableSafeMode(
         enableSafeMode: Boolean,
         viewManager: LottieAnimationViewPropertyManager

--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -55,6 +55,7 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
     var scaleType: ImageView.ScaleType? = null
     var imageAssetsFolder: String? = null
     var enableMergePaths: Boolean? = null
+    var applyOpacityToLayers: Boolean? = null
     var enableSafeMode: Boolean? = null
     var colorFilters: ReadableArray? = null
     var textFilters: ReadableArray? = null
@@ -226,6 +227,11 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
         enableMergePaths?.let {
             view.enableMergePathsForKitKatAndAbove(it)
             enableMergePaths = null
+        }
+
+        applyOpacityToLayers?.let {
+            view.setApplyingOpacityToLayersEnabled(it)
+            applyOpacityToLayers = null
         }
 
         enableSafeMode?.let {

--- a/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -1,6 +1,7 @@
 package com.airbnb.android.react.lottie
 
 import android.animation.Animator
+import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setApplyOpacityToLayers
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setColorFilters
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setEnableMergePaths
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setEnableSafeMode
@@ -189,6 +190,14 @@ class LottieAnimationViewManager :
         enableMergePaths: Boolean
     ) {
         setEnableMergePaths(enableMergePaths, getOrCreatePropertyManager(view))
+    }
+
+    @ReactProp(name = "applyOpacityToLayersAndroid")
+    override fun setApplyOpacityToLayersAndroid(
+        view: LottieAnimationView,
+        applyOpacityToLayers: Boolean
+    ) {
+        setApplyOpacityToLayers(applyOpacityToLayers, getOrCreatePropertyManager(view))
     }
 
     @ReactProp(name = "enableSafeModeAndroid")

--- a/packages/core/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -6,6 +6,7 @@ import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.play
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.reset
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.resume
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setAutoPlay
+import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setApplyOpacityToLayers
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setColorFilters
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setEnableMergePaths
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setEnableSafeMode
@@ -167,6 +168,14 @@ class LottieAnimationViewManager : SimpleViewManager<LottieAnimationView>() {
     @ReactProp(name = "enableMergePathsAndroidForKitKatAndAbove")
     fun setEnableMergePaths(view: LottieAnimationView, enableMergePaths: Boolean) {
         setEnableMergePaths(enableMergePaths, getOrCreatePropertyManager(view))
+    }
+
+    @ReactProp(name = "applyOpacityToLayersAndroid")
+    fun setApplyOpacityToLayersAndroid(
+        view: LottieAnimationView,
+        applyOpacityToLayers: Boolean
+    ) {
+        setApplyOpacityToLayers(applyOpacityToLayers, getOrCreatePropertyManager(view))
     }
 
     @ReactProp(name = "enableSafeModeAndroid")

--- a/packages/core/src/LottieView/index.tsx
+++ b/packages/core/src/LottieView/index.tsx
@@ -24,6 +24,7 @@ const defaultProps: Props = {
   loop: true,
   autoPlay: false,
   enableMergePathsAndroidForKitKatAndAbove: false,
+  applyOpacityToLayersAndroid: false,
   enableSafeModeAndroid: false,
   cacheComposition: true,
   useNativeLooping: false,

--- a/packages/core/src/specs/LottieAnimationViewNativeComponent.ts
+++ b/packages/core/src/specs/LottieAnimationViewNativeComponent.ts
@@ -46,6 +46,7 @@ export interface NativeProps extends ViewProps {
   loop?: boolean;
   autoPlay?: boolean;
   enableMergePathsAndroidForKitKatAndAbove?: boolean;
+  applyOpacityToLayersAndroid?: boolean;
   enableSafeModeAndroid?: boolean
   hardwareAccelerationAndroid?: boolean;
   cacheComposition?: boolean;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -157,6 +157,14 @@ export interface LottieViewProps {
   enableMergePathsAndroidForKitKatAndAbove?: boolean;
 
   /**
+   * A boolean flag to apply opacity to layers instead of shapes on Android.
+   * This is more accurate when translucent shapes overlap, but may impact performance.
+   *
+   * @platform android
+   */
+  applyOpacityToLayersAndroid?: boolean;
+
+  /**
    * A boolean flag to enable safe mode which wraps the draw call with a try catch on Android
    * @platform android
    */


### PR DESCRIPTION
## Summary

Closes #1436.

This exposes Android's `LottieAnimationView.setApplyingOpacityToLayersEnabled(...)` as a React Native prop:

```tsx
<LottieView applyOpacityToLayersAndroid />
```

The new prop is named `applyOpacityToLayersAndroid` and defaults to `false` to preserve the current rendering/performance behavior. When enabled, Android applies opacity to composited layers instead of individual shapes, which avoids bleed-through artifacts for overlapping translucent/precomp layers.

## What changed

- Added `applyOpacityToLayersAndroid?: boolean` to the public TypeScript props.
- Added the prop to the native component codegen spec.
- Wired the prop through both Android old architecture and new architecture managers.
- Applied it in `LottieAnimationViewPropertyManager` via `setApplyingOpacityToLayersEnabled`.

## Test plan

Passed locally:

- `yarn install --immutable`
- `yarn workspace lottie-react-native build`
- `yarn tsc`
- `git diff --check`

Attempted but blocked by local environment:

- `yarn workspace lottie-react-native exec eslint src --ext .ts,.tsx`
  - Failed because the existing ESLint config references missing dependency `@react-native/eslint-plugin-specs`.
- `./gradlew compileDebugKotlin`
  - Gradle dependency resolution/configuration did not complete reliably in this sandbox. Offline mode also failed because `com.android.tools.build:gradle:7.2.2` and `org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10` were not cached.

## Compatibility

- Android: implemented
- iOS: not changed
- Web: not changed
- Windows: not changed
