### PR TITLE
feat(core): add Swift Package Manager support for React Native 0.87

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: SwiftLint
         run: yarn lint:swift
 
+      - name: Check Package.swift matches the podspec
+        run: yarn lint:spm-parity
+
       # --- lottie-react-native-nitro (v8, not yet the default) ---
 
       - name: Compile TypeScript for Nitro Package

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "run:bundler": "yarn workspace example start",
     "run:web": "yarn workspace example web",
     "lint:swift": "yarn workspace lottie-react-native lint:swift",
+    "lint:spm-parity": "yarn workspace lottie-react-native lint:spm-parity",
     "tsc": "yarn workspace example tsc",
     "nitro:codegen": "yarn workspace lottie-react-native-nitro nitrogen",
     "nitro:tsc:lib": "yarn workspace lottie-react-native-nitro typecheck",

--- a/packages/core/Package.swift
+++ b/packages/core/Package.swift
@@ -1,0 +1,75 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let reactHeaders: [Target.Dependency] = [
+    .product(name: "ReactHeaders", package: "ReactNative"),
+    .product(name: "ReactNativeHeaders", package: "ReactNative"),
+    .product(name: "ReactNativeDependenciesHeaders", package: "ReactNative"),
+    .product(name: "ReactAppHeaders", package: "React-GeneratedCode"),
+]
+
+let package = Package(
+    name: "LottieReactNative",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "LottieReactNative",
+            targets: ["LottieReactNative", "LottieReactNativeObjC"]
+        ),
+    ],
+    dependencies: [
+        .package(name: "ReactNative", path: "../../../../xcframeworks"),
+        .package(name: "React-GeneratedCode", path: "../../../ios"),
+        .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.6.0"),
+    ],
+    targets: [
+        .target(
+            name: "LottieReactNativeObjC",
+            dependencies: reactHeaders,
+            path: "ios",
+            sources: [
+                "Fabric/LottieAnimationViewComponentView.mm",
+                "LottieReactNative/LRNAnimationViewManagerObjC.m",
+                "LottieReactNative/RCTConvert+Lottie.m",
+            ],
+            publicHeadersPath: "Fabric",
+            cSettings: [
+                .headerSearchPath("Fabric"),
+                .headerSearchPath("LottieReactNative"),
+            ],
+            cxxSettings: [
+                .headerSearchPath("Fabric"),
+                .headerSearchPath("LottieReactNative"),
+                .define("DEBUG", .when(configuration: .debug)),
+                .define("NDEBUG", .when(configuration: .release)),
+            ],
+            linkerSettings: [
+                .linkedFramework("UIKit"),
+                .linkedFramework("Foundation"),
+                .linkedFramework("CoreGraphics"),
+            ]
+        ),
+        .target(
+            name: "LottieReactNative",
+            dependencies: reactHeaders + [
+                .product(name: "Lottie", package: "lottie-ios"),
+            ],
+            path: "ios",
+            sources: [
+                "LottieReactNative/AnimationViewManagerModule.swift",
+                "LottieReactNative/ContainerView.swift",
+                "LottieReactNative/PlatformColor.swift",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
+            ],
+            linkerSettings: [
+                .linkedFramework("UIKit"),
+                .linkedFramework("Foundation"),
+                .linkedFramework("CoreGraphics"),
+            ]
+        ),
+    ],
+    cxxLanguageStandard: .cxx20
+)

--- a/packages/core/ios/Fabric/LottieAnimationViewComponentView.mm
+++ b/packages/core/ios/Fabric/LottieAnimationViewComponentView.mm
@@ -5,7 +5,7 @@
 #import <react/renderer/components/lottiereactnative/Props.h>
 #import <react/renderer/components/lottiereactnative/RCTComponentViewHelpers.h>
 
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTView.h>
 #import "LottieContainerView.h"
 #import "RNLottieFabricConversions.h"

--- a/packages/core/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/packages/core/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -1,4 +1,5 @@
 import Lottie
+import React
 
 #if os(OSX)
 import AppKit

--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -1,5 +1,6 @@
 import Lottie
 import Foundation
+import React
 
 @objc protocol LottieContainerViewDelegate {
     func onAnimationFinish(isCancelled: Bool)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "lib",
     "android",
     "ios",
+    "Package.swift",
     "*.podspec",
     "react-native.config.js",
     "windows"
@@ -41,7 +42,8 @@
     "prepare": "bob build",
     "lint:swift": "swiftlint ios",
     "lint-fix:swift": "swiftlint --fix ios",
-    "release": "npm publish"
+    "release": "npm publish",
+    "lint:spm-parity": "node scripts/check-spm-parity.js"
   },
   "peerDependencies": {
     "@lottiefiles/dotlottie-react": "^0.13.5",

--- a/packages/core/scripts/check-spm-parity.js
+++ b/packages/core/scripts/check-spm-parity.js
@@ -1,0 +1,110 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageRoot = path.resolve(__dirname, '..');
+const manifestPath = path.join(packageRoot, 'Package.swift');
+const podspecPath = path.join(packageRoot, 'lottie-react-native.podspec');
+const iosRoot = path.join(packageRoot, 'ios');
+
+const COMPILED = new Set(['.swift', '.m', '.mm']);
+const MANIFEST_ONLY_DIRS = new Set(['LottieReactNative.xcodeproj']);
+
+function fail(lines) {
+  console.error('spm-parity: Package.swift and the podspec disagree.\n');
+  for (const line of lines) {
+    console.error(`  ${line}`);
+  }
+  console.error(
+    '\nUpdate packages/core/Package.swift so both manifests describe the same build.',
+  );
+  process.exit(1);
+}
+
+function walk(dir, base = '') {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    if (MANIFEST_ONLY_DIRS.has(entry.name)) continue;
+    const rel = base ? `${base}/${entry.name}` : entry.name;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(abs, rel));
+    } else if (COMPILED.has(path.extname(entry.name))) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+function manifestSources(manifest) {
+  const found = new Set();
+  const blocks = manifest.matchAll(/sources:\s*\[([^\]]*)\]/g);
+  for (const block of blocks) {
+    for (const entry of block[1].matchAll(/"([^"]+)"/g)) {
+      found.add(entry[1]);
+    }
+  }
+  return found;
+}
+
+function podspecLottieVersion(podspec) {
+  const match = podspec.match(/s\.dependency\s+['"]lottie-ios['"]\s*,\s*['"]([^'"]+)['"]/);
+  return match ? match[1] : null;
+}
+
+function manifestLottieVersion(manifest) {
+  const match = manifest.match(/lottie-ios\.git["']\s*,\s*exact:\s*"([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+function main() {
+  for (const required of [manifestPath, podspecPath]) {
+    if (!fs.existsSync(required)) {
+      fail([`missing ${path.relative(packageRoot, required)}`]);
+    }
+  }
+
+  const manifest = fs.readFileSync(manifestPath, 'utf8');
+  const podspec = fs.readFileSync(podspecPath, 'utf8');
+  const problems = [];
+
+  const onDisk = walk(iosRoot).sort();
+  const declared = manifestSources(manifest);
+
+  for (const file of onDisk) {
+    if (!declared.has(file)) {
+      problems.push(`ios/${file} is compiled by the podspec but absent from Package.swift`);
+    }
+  }
+  for (const file of [...declared].sort()) {
+    if (!fs.existsSync(path.join(iosRoot, file))) {
+      problems.push(`Package.swift lists ios/${file}, which does not exist`);
+    }
+  }
+
+  const podLottie = podspecLottieVersion(podspec);
+  const spmLottie = manifestLottieVersion(manifest);
+  if (podLottie == null) {
+    problems.push('could not read the lottie-ios version from the podspec');
+  } else if (spmLottie == null) {
+    problems.push('could not read the lottie-ios version from Package.swift');
+  } else if (podLottie !== spmLottie) {
+    problems.push(`lottie-ios is ${podLottie} in the podspec and ${spmLottie} in Package.swift`);
+  }
+
+  const files = JSON.parse(
+    fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+  ).files;
+  if (!files.includes('Package.swift')) {
+    problems.push('package.json "files" does not include Package.swift, so it would not be published');
+  }
+
+  if (problems.length > 0) {
+    fail(problems);
+  }
+
+  console.log(
+    `spm-parity: ok — ${onDisk.length} compiled sources, lottie-ios ${podLottie}`,
+  );
+}
+
+main();


### PR DESCRIPTION
RN 0.87 lets libraries support Swift Package Manager instead of CocoaPods. This adds that to v7 only. 

What's in it: a Package.swift in packages/core, a lint check, and three one-line source edits.

Why hand-written: RN's spm scaffold generates the manifest for you, but it refuses any library mixing Swift and ObjC in one target - which we do. Its suggested fallback (spm.xcframework) is documented but   
  not actually implemented in 0.87. So it's written by hand, which RN also says is the preferred outcome anyway.                                                                                                 
                                                                                                                                                                                                                 
Two targets because SPM won't mix languages. They don't depend on each other - our ObjC talks to Swift via a hand-written header, not a generated one - so no circular dependency, and no files had to move.   
                                                                                                                                                                                                                 
The manifest sits at the package root, not ios/. Under ios/ the podspec glob picks it up and CocoaPods tries to compile it. That broke the example app; the root avoids it.                                    
                                                                                                                                                                                                                 
Three source edits - import React in two Swift files, and one header import switched to the angle-bracket form. All no-ops for CocoaPods.                                                                  
                                                                                                                                                                                                                 
Tested: builds under SPM on 0.87, and still builds under CocoaPods on 0.84.1. Not tested on device, and only the default pods setup.
<img width="1728" height="1024" alt="Screenshot 2026-08-16 at 20 56 31" src="https://github.com/user-attachments/assets/cc5ca8c1-7000-414e-b6ba-9d8cd87c8dba" />
